### PR TITLE
Warp perlin

### DIFF
--- a/core/src/com/unciv/logic/map/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/MapGenerator.kt
@@ -104,7 +104,7 @@ class MapGenerator(val ruleset: Ruleset) {
 
                 val elevation = getRidgedPerlinNoise(tile, seed, scale = 10.0)
 
-                if (elevation > 0.25)
+                if (elevation > 0.3)
                     tile.baseTerrain = Constants.mountain
                 tile.setTransients()
             }

--- a/core/src/com/unciv/logic/map/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/MapGenerator.kt
@@ -98,7 +98,7 @@ class MapGenerator(val ruleset: Ruleset) {
 
     private fun randomizeTiles(tileMap: TileMap) {
         for (tile in tileMap.values) {
-            if (tileMap.mapParameters.type != MapType.mountainRange && tile.getBaseTerrain().type == TerrainType.Land && RNG.nextDouble() < tileMap.mapParameters.mountainProbability) {
+            if (tile.getBaseTerrain().type == TerrainType.Land && RNG.nextDouble() < tileMap.mapParameters.mountainProbability) {
                 tile.baseTerrain = Constants.mountain
                 tile.setTransients()
             }
@@ -566,7 +566,6 @@ class MapGenerator(val ruleset: Ruleset) {
                 MapType.archipelago -> createArchipelago(tileMap)
                 MapType.warpPerlin -> createWarpPerlin(tileMap)
                 MapType.diverseArchipelago -> createDiverseArchipelago(tileMap)
-                MapType.mountainRange -> createMountainRange(tileMap)
                 MapType.default -> generateLandCellularAutomata(tileMap)
             }
         }

--- a/core/src/com/unciv/logic/map/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/MapGenerator.kt
@@ -98,8 +98,17 @@ class MapGenerator(val ruleset: Ruleset) {
 
     private fun randomizeTiles(tileMap: TileMap) {
 
+        val seed = RNG.nextInt().toDouble()
         for (tile in tileMap.values) {
-            if (tile.getBaseTerrain().type == TerrainType.Land && RNG.nextDouble() < tileMap.mapParameters.mountainProbability) {
+            if (tileMap.mapParameters.type == MapType.mountainRange && tile.getBaseTerrain().type == TerrainType.Land) {
+
+                val elevation = getRidgedPerlinNoise(tile, seed, scale = 10.0)
+
+                if (elevation > 0.25)
+                    tile.baseTerrain = Constants.mountain
+                tile.setTransients()
+            }
+            if (tileMap.mapParameters.type != MapType.mountainRange && tile.getBaseTerrain().type == TerrainType.Land && RNG.nextDouble() < tileMap.mapParameters.mountainProbability) {
                 tile.baseTerrain = Constants.mountain
                 tile.setTransients()
             }
@@ -567,6 +576,7 @@ class MapGenerator(val ruleset: Ruleset) {
                 MapType.archipelago -> createArchipelago(tileMap)
                 MapType.warpPerlin -> createWarpPerlin(tileMap)
                 MapType.diverseArchipelago -> createDiverseArchipelago(tileMap)
+                MapType.mountainRange -> createMountainRange(tileMap)
                 MapType.default -> generateLandCellularAutomata(tileMap)
             }
         }
@@ -628,6 +638,18 @@ class MapGenerator(val ruleset: Ruleset) {
                 val weight = 4.0
 
                 val elevation = noise1 + noise2*weight-1.08
+                when {
+                    elevation < 0 -> tile.baseTerrain = Constants.ocean
+                    else -> tile.baseTerrain = Constants.grassland
+                }
+            }
+        }
+
+        private fun createMountainRange(tileMap: TileMap) {
+            val elevationSeed = RNG.nextInt().toDouble()
+            for (tile in tileMap.values) {
+                var elevation = getRidgedPerlinNoise(tile, elevationSeed) - 0.1
+
                 when {
                     elevation < 0 -> tile.baseTerrain = Constants.ocean
                     else -> tile.baseTerrain = Constants.grassland

--- a/core/src/com/unciv/logic/map/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/MapGenerator.kt
@@ -634,18 +634,6 @@ class MapGenerator(val ruleset: Ruleset) {
             }
         }
 
-        private fun createMountainRange(tileMap: TileMap) {
-            val elevationSeed = RNG.nextInt().toDouble()
-            for (tile in tileMap.values) {
-                var elevation = getRidgedPerlinNoise(tile, elevationSeed) - 0.1
-
-                when {
-                    elevation < 0 -> tile.baseTerrain = Constants.ocean
-                    else -> tile.baseTerrain = Constants.grassland
-                }
-            }
-        }
-
         private fun createPangea(tileMap: TileMap) {
             val elevationSeed = RNG.nextInt().toDouble()
             for (tile in tileMap.values) {

--- a/core/src/com/unciv/logic/map/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/MapGenerator.kt
@@ -566,6 +566,7 @@ class MapGenerator(val ruleset: Ruleset) {
                 MapType.perlin -> createPerlin(tileMap)
                 MapType.archipelago -> createArchipelago(tileMap)
                 MapType.warpPerlin -> createWarpPerlin(tileMap)
+                MapType.diverseArchipelago -> createDiverseArchipelago(tileMap)
                 MapType.default -> generateLandCellularAutomata(tileMap)
             }
         }
@@ -610,6 +611,23 @@ class MapGenerator(val ruleset: Ruleset) {
             val elevationSeed = RNG.nextInt().toDouble()
             for (tile in tileMap.values) {
                 val elevation = getNormalWarpPerlinNoise(tile, elevationSeed)
+                when {
+                    elevation < 0 -> tile.baseTerrain = Constants.ocean
+                    else -> tile.baseTerrain = Constants.grassland
+                }
+            }
+        }
+
+        private fun createDiverseArchipelago(tileMap: TileMap) {
+            val elevationSeed1 = RNG.nextInt().toDouble()
+            val elevationSeed2 = RNG.nextInt().toDouble()
+            for (tile in tileMap.values) {
+                val noise1 = getNormalWarpPerlinNoise(tile, elevationSeed1, scale = 15.0)
+                val noise2 = getRidgedPerlinNoise(tile, elevationSeed2)
+
+                val weight = 4.0
+
+                val elevation = noise1 + noise2*weight-1.08
                 when {
                     elevation < 0 -> tile.baseTerrain = Constants.ocean
                     else -> tile.baseTerrain = Constants.grassland

--- a/core/src/com/unciv/logic/map/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/MapGenerator.kt
@@ -599,7 +599,6 @@ class MapGenerator(val ruleset: Ruleset) {
             val elevationSeed = RNG.nextInt().toDouble()
             for (tile in tileMap.values) {
                 var elevation = getRidgedPerlinNoise(tile, elevationSeed)-0.25
-                //val elevation = getNormalWarpPerlinNoise(tile, elevationSeed)
                 when {
                     elevation < 0 -> tile.baseTerrain = Constants.ocean
                     else -> tile.baseTerrain = Constants.grassland

--- a/core/src/com/unciv/logic/map/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/MapGenerator.kt
@@ -97,17 +97,7 @@ class MapGenerator(val ruleset: Ruleset) {
     }
 
     private fun randomizeTiles(tileMap: TileMap) {
-
-        val seed = RNG.nextInt().toDouble()
         for (tile in tileMap.values) {
-            if (tileMap.mapParameters.type == MapType.mountainRange && tile.getBaseTerrain().type == TerrainType.Land) {
-
-                val elevation = getRidgedPerlinNoise(tile, seed, scale = 10.0)
-
-                if (elevation > 0.3)
-                    tile.baseTerrain = Constants.mountain
-                tile.setTransients()
-            }
             if (tileMap.mapParameters.type != MapType.mountainRange && tile.getBaseTerrain().type == TerrainType.Land && RNG.nextDouble() < tileMap.mapParameters.mountainProbability) {
                 tile.baseTerrain = Constants.mountain
                 tile.setTransients()

--- a/core/src/com/unciv/logic/map/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/MapGenerator.kt
@@ -565,6 +565,7 @@ class MapGenerator(val ruleset: Ruleset) {
                 MapType.continents -> createTwoContinents(tileMap)
                 MapType.perlin -> createPerlin(tileMap)
                 MapType.archipelago -> createArchipelago(tileMap)
+                MapType.warpPerlin -> createWarpPerlin(tileMap)
                 MapType.default -> generateLandCellularAutomata(tileMap)
             }
         }
@@ -598,7 +599,18 @@ class MapGenerator(val ruleset: Ruleset) {
             val elevationSeed = RNG.nextInt().toDouble()
             for (tile in tileMap.values) {
                 var elevation = getRidgedPerlinNoise(tile, elevationSeed)-0.25
+                //val elevation = getNormalWarpPerlinNoise(tile, elevationSeed)
+                when {
+                    elevation < 0 -> tile.baseTerrain = Constants.ocean
+                    else -> tile.baseTerrain = Constants.grassland
+                }
+            }
+        }
 
+        private fun createWarpPerlin(tileMap: TileMap) {
+            val elevationSeed = RNG.nextInt().toDouble()
+            for (tile in tileMap.values) {
+                val elevation = getNormalWarpPerlinNoise(tile, elevationSeed)
                 when {
                     elevation < 0 -> tile.baseTerrain = Constants.ocean
                     else -> tile.baseTerrain = Constants.grassland
@@ -673,6 +685,15 @@ class MapGenerator(val ruleset: Ruleset) {
                                          scale: Double = 15.0): Double {
             val worldCoords = HexMath.hex2WorldCoords(tile.position)
             return Perlin.ridgedNoise3d(worldCoords.x.toDouble(), worldCoords.y.toDouble(), seed, nOctaves, persistence, lacunarity, scale)
+        }
+
+        private fun getNormalWarpPerlinNoise(tile: TileInfo, seed: Double,
+                                             nOctaves: Int = 10,
+                                             persistence: Double = 0.5,
+                                             lacunarity: Double = 2.0,
+                                             scale: Double = 40.0): Double {
+            val worldCoords = HexMath.hex2WorldCoords(tile.position)
+            return Perlin.normalWarpNoise3d(worldCoords.x.toDouble(), worldCoords.y.toDouble(), seed, nOctaves, persistence, lacunarity, scale)
         }
 
         // region Cellular automata

--- a/core/src/com/unciv/logic/map/MapParameters.kt
+++ b/core/src/com/unciv/logic/map/MapParameters.kt
@@ -18,6 +18,7 @@ object MapType {
     const val continents = "Continents"
     const val perlin = "Perlin"
     const val archipelago = "Archipelago"
+    const val warpPerlin = "warp perlin"
 
     // Cellular automata
     const val default = "Default"

--- a/core/src/com/unciv/logic/map/MapParameters.kt
+++ b/core/src/com/unciv/logic/map/MapParameters.kt
@@ -20,7 +20,6 @@ object MapType {
     const val archipelago = "Archipelago"
     const val warpPerlin = "warp perlin"
     const val diverseArchipelago = "Diverse Archipelago"
-    const val mountainRange = "Mountain Range"
 
     // Cellular automata
     const val default = "Default"

--- a/core/src/com/unciv/logic/map/MapParameters.kt
+++ b/core/src/com/unciv/logic/map/MapParameters.kt
@@ -19,6 +19,7 @@ object MapType {
     const val perlin = "Perlin"
     const val archipelago = "Archipelago"
     const val warpPerlin = "warp perlin"
+    const val diverseArchipelago = "Diverse Archipelago"
 
     // Cellular automata
     const val default = "Default"

--- a/core/src/com/unciv/logic/map/MapParameters.kt
+++ b/core/src/com/unciv/logic/map/MapParameters.kt
@@ -20,6 +20,7 @@ object MapType {
     const val archipelago = "Archipelago"
     const val warpPerlin = "warp perlin"
     const val diverseArchipelago = "Diverse Archipelago"
+    const val mountainRange = "Mountain Range"
 
     // Cellular automata
     const val default = "Default"

--- a/core/src/com/unciv/logic/map/Perlin.kt
+++ b/core/src/com/unciv/logic/map/Perlin.kt
@@ -2,6 +2,8 @@ package com.unciv.logic.map
 
 import kotlin.math.floor
 import kotlin.math.abs
+import kotlin.math.pow
+import kotlin.math.sqrt
 
 // version 1.1.3
 // From https://rosettacode.org/wiki/Perlin_noise#Kotlin
@@ -76,6 +78,34 @@ object Perlin {
             amp *= persistence
         }
         return total/max
+    }
+
+    fun normalWarpNoise3d(x: Double, y: Double, z: Double,
+                              nOctaves: Int = 3,
+                              persistence: Double = 0.5,
+                              lacunarity: Double = 2.0,
+                              scale: Double = 10.0,
+                              warpStrength: Double = 30.0) : Double {
+        var warpx = noise3d(x, y, z, nOctaves, persistence, lacunarity, scale)
+        var warpy = noise3d(x, y, z+1000.0, nOctaves, persistence, lacunarity, scale)
+        var warpz = noise3d(x, y, z+2000.0, nOctaves, persistence, lacunarity, scale)
+
+        val norm = sqrt(warpx.pow(2)+ warpy.pow(2)+warpz.pow(2))
+
+        if (norm > 0) {
+            warpx /= norm
+            warpy /= norm
+            warpz /= norm
+        }
+
+
+        val magnitude = noise3d(x,y,z+3000.0, nOctaves, persistence, lacunarity, scale)+1.0
+
+        warpx*=warpStrength*magnitude
+        warpy*=warpStrength*magnitude
+        warpz*=warpStrength*magnitude
+
+        return noise3d(x+warpx, y+warpy, z+warpz+4000.0, nOctaves, persistence, lacunarity, scale)
     }
 
     fun noise(x: Double, y: Double, z: Double): Double {

--- a/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
@@ -65,6 +65,7 @@ class MapParametersTable(val mapParameters: MapParameters, val isEmptyMapAllowed
             MapType.archipelago,
             MapType.warpPerlin,
             MapType.diverseArchipelago,
+            MapType.mountainRange,
             if (isEmptyMapAllowed) MapType.empty else null
         )
 

--- a/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
@@ -63,6 +63,7 @@ class MapParametersTable(val mapParameters: MapParameters, val isEmptyMapAllowed
             MapType.continents,
             MapType.perlin,
             MapType.archipelago,
+            MapType.warpPerlin,
             if (isEmptyMapAllowed) MapType.empty else null
         )
 

--- a/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
@@ -65,7 +65,6 @@ class MapParametersTable(val mapParameters: MapParameters, val isEmptyMapAllowed
             MapType.archipelago,
             MapType.warpPerlin,
             MapType.diverseArchipelago,
-            MapType.mountainRange,
             if (isEmptyMapAllowed) MapType.empty else null
         )
 

--- a/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
@@ -64,6 +64,7 @@ class MapParametersTable(val mapParameters: MapParameters, val isEmptyMapAllowed
             MapType.perlin,
             MapType.archipelago,
             MapType.warpPerlin,
+            MapType.diverseArchipelago,
             if (isEmptyMapAllowed) MapType.empty else null
         )
 


### PR DESCRIPTION
warpPerlin : Another type of map which apply a domain warping to perlin noise. The difference with usual perlin noise can be particularly seen on huge map.

Diverse Archipelago : an archipelago map using warpPerlin and ridgednoise

Mountain Range : a map which is almost completely land, with big mountains strings generated with ridged perlin noise